### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/app/views/hyrax/datasets/_dataset_versions.html.erb
+++ b/app/views/hyrax/datasets/_dataset_versions.html.erb
@@ -27,7 +27,7 @@
 	<%= num_versions - i %>
       </td>
       <td>
-	<%= link_to_unless ver.id == presenter.solr_document.id, ver.doi, "https://dx.doi.org/#{ver.doi}" %>
+	<%= link_to_unless ver.id == presenter.solr_document.id, ver.doi, "https://doi.org/#{ver.doi}" %>
       </td>
       <td>
 	<%= Array(ver.provenance).last %>


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver URL](https://www.doi.org/doi_handbook/3_Resolution.html#3.8).

Cheers!

PS: Follow-up to #71 