### PR TITLE
Report error rather than throwing exception for invalid column headin…

### DIFF
--- a/config/locales/rdr.en.yml
+++ b/config/locales/rdr.en.yml
@@ -20,6 +20,7 @@ en:
     not_found: "%{target} could not be found"
     batch_import:
       heading: "Batch Import"
+      invalid_metadata_header: "Invalid header: %{header}"
       invalid_metadata_value: "Invalid value: %{value}"
     doi:
       assigment_registration_job_enqueued: 'Queued up DOI assignment and registration job'

--- a/lib/importer/csv_manifest.rb
+++ b/lib/importer/csv_manifest.rb
@@ -21,8 +21,13 @@ module Importer
       controlled_vocabularies_values[vocab_name]
     end
 
+    def self.valid_headers
+      Dataset.attribute_names + %w(collection_id parent_ark visibility file)
+    end
+
     attr_reader :files_directory, :manifest_file
 
+    validate :metadata_headers
     validate :controlled_vocabulary_values
     validate :files_must_exist
 
@@ -33,6 +38,14 @@ module Importer
 
     def parser
       @parser ||= CSVParser.new(manifest_file)
+    end
+
+    def metadata_headers
+      parser.headers.each do |header|
+        unless self.class.valid_headers.include?(header)
+          errors.add(:base, I18n.t('rdr.batch_import.invalid_metadata_header', header: header))
+        end
+      end
     end
 
     def controlled_vocabulary_values

--- a/spec/fixtures/importer/manifest_samples/invalid_headers.csv
+++ b/spec/fixtures/importer/manifest_samples/invalid_headers.csv
@@ -1,0 +1,4 @@
+visibility,title,contributor,bad_header,ungood_header,file,file,file
+open,Test 1,"Smith, Sue",Dataset,"http://creativecommons.org/publicdomain/zero/1.0/",data/data1.csv,data/data2.csv,docs/doc1.txt
+,Test 2,"Jones, Bill",Dataset,"http://creativecommons.org/publicdomain/zero/1.0/",data/data3.csv,docs/doc2.txt
+authenticated,Test 3,"Allen, Jane",Dataset,"http://creativecommons.org/publicdomain/zero/1.0/",data/data1.csv

--- a/spec/lib/importer/csv_manifest_spec.rb
+++ b/spec/lib/importer/csv_manifest_spec.rb
@@ -21,6 +21,18 @@ module Importer
         end
       end
       describe 'invalid manifest' do
+        describe 'invalid header' do
+          let(:manifest_file) do
+            File.join(fixture_path, 'importer', 'manifest_samples', 'invalid_headers.csv')
+          end
+          it 'has an invalid header error' do
+            expect(subject).to_not be_valid
+            expect(subject.errors.messages[:base])
+                .to include(I18n.t('rdr.batch_import.invalid_metadata_header', header: 'bad_header'))
+            expect(subject.errors.messages[:base])
+                .to include(I18n.t('rdr.batch_import.invalid_metadata_header', header: 'ungood_header'))
+          end
+        end
         describe 'invalid controlled vocabulary metadata value' do
           let(:manifest_file) do
             File.join(fixture_path, 'importer', 'manifest_samples', 'invalid_controlled_vocab_values.csv')

--- a/spec/lib/importer/csv_parser_spec.rb
+++ b/spec/lib/importer/csv_parser_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 require 'importer'
 
 RSpec.describe Importer::CSVParser do
-  let(:parser) { described_class.new(file) }
-  let(:attributes) { parser.attributes }
   let(:file) { "#{fixture_path}/importer/manifest_samples/sample.csv" }
-  let(:first_record) { parser.first }
+  let(:first_record) { subject.first }
+
+  subject { described_class.new(file) }
 
   context 'parsing metadata file' do
     it 'parses a record' do
@@ -19,31 +19,8 @@ RSpec.describe Importer::CSVParser do
     end
   end
 
-  describe 'validating CSV headers' do
-    subject { parser.send(:validate_headers, headers) }
-
-    context 'with valid headers' do
-      let(:headers) { %w(title parent_ark) }
-      it { is_expected.to eq headers }
-    end
-
-    context 'with invalid headers' do
-      let(:headers) { ['something bad', 'title'] }
-
-      it 'raises an error' do
-        expect { subject }.to raise_error 'Invalid headers: something bad'
-      end
-    end
-
-    context 'with nil headers' do
-      let(:headers) { ['title', nil] }
-      it { is_expected.to eq headers }
-    end
-
-    context 'with resource_type column' do
-      let(:headers) { %w(resource_type title) }
-      it { is_expected.to eq headers }
-    end
+  describe '#headers' do
+    specify { expect(subject.headers).to eq(%w(visibility title contributor resource_type license file file file)) }
   end
 
 end


### PR DESCRIPTION
…g in batch import manifest file; RDR-222.

Move manifest file column heading validation from Importer::CSVParser to Importer::CSVManifest.  Also, refactors Importer::CSVParser to support heading validation in Importer::CSVManifest and to clean up the code.