### PR TITLE
Override one method in the Hyrax resource list writer so RDR sitemap …

### DIFF
--- a/config/initializers/resource_sync.rb
+++ b/config/initializers/resource_sync.rb
@@ -1,0 +1,14 @@
+Hyrax::ResourceSync::ResourceListWriter.class_eval do
+  # Prevent file URLs from being listed in the RDR sitemap. This is done by
+  # overriding a private method in Hyrax core's ResourceSync Resource List Writer.
+  # https://github.com/samvera/hyrax/blob/master/lib/hyrax/resource_sync/resource_list_writer.rb#L46-L50
+
+  # Verify that this override is still needed for Hyrax::VERSION above 2.5.1.
+  # Refactoring how sitemaps/resource lists are written is slated for work in
+  # the Hyrax 3.x series, since it is important that fewer than 50K URLs are
+  # listed in any one sitemap file. See https://github.com/samvera/hyrax/issues/59.
+
+  def build_files(xml)
+    # Do nothing: don't include file URLs in the RDR sitemap
+  end
+end

--- a/spec/factories/datasets.rb
+++ b/spec/factories/datasets.rb
@@ -46,7 +46,7 @@ FactoryBot.define do
     end
 
     factory :public_dataset_with_public_files, traits: [:public] do
-      before(:create) { |work, evaluator| 2.times { work.ordered_members << FactoryBot.create(:file_set, user: evaluator.user, traits: [:public]) } }
+      before(:create) { |work, evaluator| 2.times { work.ordered_members << FactoryBot.create(:public_file_set, user: evaluator.user) } }
     end
 
     factory :dataset_with_ordered_files do
@@ -66,6 +66,13 @@ FactoryBot.define do
       before(:create) do |work, evaluator|
         work.ordered_members << FactoryBot.create(:dataset, user: evaluator.user, title: ['A Contained Work'], id: "BlahBlah1")
         work.ordered_members << FactoryBot.create(:dataset, user: evaluator.user, title: ['Another Contained Work'], id: "BlahBlah2")
+      end
+    end
+
+    factory :dataset_with_two_public_children do
+      before(:create) do |work, evaluator|
+        work.ordered_members << FactoryBot.create(:public_dataset, user: evaluator.user, title: ['A Public Contained Work'], id: "BlahBlah3")
+        work.ordered_members << FactoryBot.create(:public_dataset, user: evaluator.user, title: ['Another Public Contained Work'], id: "BlahBlah4")
       end
     end
 

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -14,6 +14,8 @@ FactoryBot.define do
       end
     end
 
+    factory :public_file_set, traits: [:public]
+
     trait :public do
       read_groups ["public"]
     end

--- a/spec/lib/hyrax/resource_sync/resource_list_writer_spec.rb
+++ b/spec/lib/hyrax/resource_sync/resource_list_writer_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+# Tests monkey-patched Hyrax core ResourceSync list writer
+# to ensure RDR sitemaps include all works but don't include files
+# https://github.com/samvera/hyrax/blob/master/spec/lib/hyrax/resource_sync/resource_list_writer_spec.rb
+RSpec.describe Hyrax::ResourceSync::ResourceListWriter, :clean_repo do
+  let(:sitemap) { 'http://www.sitemaps.org/schemas/sitemap/0.9' }
+
+  let!(:dataset_one) { FactoryBot.create(:public_dataset) }
+  let!(:dataset_two) { FactoryBot.create(:dataset_with_two_public_children, :public) }
+  let!(:dataset_three) { FactoryBot.create(:public_dataset_with_public_files) }
+  let!(:dataset_four) { FactoryBot.create(:dataset) } # not public
+
+  let(:xml) { Nokogiri::XML.parse(subject) }
+
+  subject { described_class.new(resource_host: 'research.repository.duke.edu', capability_list_url: 'https://research.repository.duke.edu/capabilitylist').write }
+
+  it "lists public top-level work URLs" do
+    expect(subject).to match(/research.repository.duke.edu\/concern\/datasets\/#{dataset_one.id}/)
+    expect(subject).to match(/research.repository.duke.edu\/concern\/datasets\/#{dataset_two.id}/)
+    expect(subject).to match(/research.repository.duke.edu\/concern\/datasets\/#{dataset_three.id}/)
+  end
+
+  it "lists public work URLs even if nested" do
+    expect(subject).to match(/research.repository.duke.edu\/concern\/datasets\/BlahBlah3/)
+    expect(subject).to match(/research.repository.duke.edu\/concern\/datasets\/BlahBlah4/)
+  end
+
+  it "omits non-public work URLs" do
+    expect(subject).not_to match(/research.repository.duke.edu\/concern\/datasets\/#{dataset_four.id}/)
+  end
+
+  it "omits file_set URLs" do
+    expect(subject).not_to match(/research.repository.duke.edu\/concern\/file_sets\//)
+  end
+end


### PR DESCRIPTION
…will only list URLs for collections & works (not files).