### PR TITLE
Extend dataset citation to full-width in search results; remove thumb…

### DIFF
--- a/app/assets/stylesheets/rdr.scss
+++ b/app/assets/stylesheets/rdr.scss
@@ -177,6 +177,12 @@ body {
   color: $gray;
 }
 
+.list-thumbnail {
+  @media screen and (max-width: $screen-sm-max) {
+    display: none;
+  }
+}
+
 
 /* ========= */
 /*  Columns  */

--- a/app/views/catalog/_index_list_dataset.html.erb
+++ b/app/views/catalog/_index_list_dataset.html.erb
@@ -1,0 +1,15 @@
+<%# NOTE: Dataset-specific substitute for Hyrax's default index_list_default.html.erb %>
+<%# See https://github.com/samvera/hyrax/blob/master/app/views/catalog/_index_list_default.html.erb %>
+<div class="col-md-10">
+  <div class="metadata">
+    <dl class="dl-horizontal">
+    <% doc_presenter = index_presenter(document) %>
+    <% index_fields(document).each do |field_name, field| -%>
+      <% if should_render_index_field? document, field %>
+          <dt><%= render_index_field_label document, field: field_name %></dt>
+          <dd><%= doc_presenter.field_value field %></dd>
+      <% end %>
+    <% end %>
+    </dl>
+  </div>
+</div>


### PR DESCRIPTION
…/icon from search results in narrowest viewport UI. Closes RDR-397. Partially addresses RDR-461.