### PR TITLE
Change the file Select Action dropdown to a Download button if all a …

### DIFF
--- a/app/assets/stylesheets/rdr.scss
+++ b/app/assets/stylesheets/rdr.scss
@@ -111,6 +111,16 @@ body {
   }
 }
 
+.btn-download {
+  font-weight: bold;
+  &:before {
+  content: "\f019";
+  font-family: FontAwesome;
+  margin-right: 0.5em;
+  color: $brand-success;
+  }
+}
+
 /* ============================================ */
 /* Background variations (extends Bootstrap)    */
 /* ============================================ */

--- a/app/views/hyrax/base/_actions.html.erb
+++ b/app/views/hyrax/base/_actions.html.erb
@@ -1,0 +1,19 @@
+<%# NOTE: Modified copy of Hyrax (v2.6.0) partial for local overrides %>
+<%# especially for an easier/clearer file download UX. %>
+<%# https://github.com/samvera/hyrax/blob/v2.6.0/app/views/hyrax/base/_actions.html.erb %>
+
+<%# Remove in future if https://github.com/samvera/hyrax/issues/147 gets fixed. %>
+
+<% if member.model_name.singular.to_sym == :file_set %>
+  <% if can?(:edit, member.id) %>
+    <%= render "hyrax/file_sets/actions", file_set: member %>
+  <% elsif can?(:download, member.id) %>
+    <%= link_to t('hyrax.file_sets.actions.download'),
+                hyrax.download_path(member),
+                class: 'btn btn-default btn-download',
+                title: t('hyrax.file_sets.actions.download_title', file_set: member),
+                target: "_blank",
+                id: ["file_download_", member.id].join,
+                data: { label: member.id } %>
+  <% end %>
+<% end %>

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -1,6 +1,11 @@
 <%# NOTE: Overrides Hyrax partial %>
 <div class="show-actions">
   <form>
+
+  <% if presenter.members %>
+    <%= link_to "Export Files", [main_app, :export_files], class: 'btn btn-default btn-download' %>
+  <% end %>
+
   <% if presenter.editor? %>
     <%= link_to "Edit", edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default' %>
     <%= link_to "Delete", [main_app, presenter], class: 'btn btn-danger', data: { confirm: "Delete this #{presenter.human_readable_type}?" }, method: :delete %>
@@ -33,13 +38,10 @@
     <%= link_to "Request Modifications",  Rdr.depositor_request_form, class: 'btn btn-default', target: "_blank" %>
   <% end %>
 
-  <% if presenter.members %>
-    <%= link_to "Export Files", [main_app, :export_files], class: 'btn btn-default' %>
-  <% end %>
-
   <% if presenter.assignable_doi? %>
     <%= link_to "Assign & Register DOI", [main_app, :assign_register_doi_hyrax_dataset], method: :post, class: 'btn btn-default' %>
   <% end %>
+
   </form>
 </div>
 

--- a/spec/views/hyrax/base/_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_actions.html.erb_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# NOTE: We may be able to remove this test and its associated partial
+# in the future if https://github.com/samvera/hyrax/issues/147 gets fixed
+# in Hyrax core.
+
+require 'rails_helper'
+
+RSpec.describe "hyrax/base/_actions.html.erb", type: :view do
+  let(:ability)  { Ability.new(user) }
+  let(:user) { FactoryBot.build(:user) }
+  let(:solr_document) {
+    SolrDocument.new( id: "bn999672v",
+                      has_model_ssim: ['FileSet'],
+                      active_fedora_model_ssi: 'FileSet', 
+    )
+  }
+  let(:member) { Hyrax::FileSetPresenter.new(solr_document, ability) }
+
+  subject { Capybara::Node::Simple.new(rendered) }
+
+  before do
+    allow(view).to receive(:current_user).and_return(user)
+    allow(controller).to receive(:current_ability).and_return(ability)
+  end
+
+  context "when the user can downlad but cannot edit" do
+    before do
+      allow(ability).to receive(:can?).with(:download, member.id).and_return(true)
+      allow(ability).to receive(:can?).with(:edit, member.id).and_return(false)
+      allow(ability).to receive(:can?).with(:destroy, member.id).and_return(false)
+      render("hyrax/base/actions", member: member)
+    end
+    it "displays only a Download button (no dropdown)" do
+      expect(subject).to have_selector('a.btn', text: "Download")
+      expect(subject).to have_selector('a#file_download_bn999672v', text: "Download")
+    end
+  end
+
+  context "when the user has edit permissions" do
+    before do
+      allow(ability).to receive(:can?).with(:download, member.id).and_return(true)
+      allow(ability).to receive(:can?).with(:edit, member.id).and_return(true)
+      allow(ability).to receive(:can?).with(:destroy, member.id).and_return(true)
+      render("hyrax/base/actions", member: member)
+    end
+    it "displays a dropdown menu including a link to download" do
+      expect(subject).to have_selector("button#dropdownMenu_bn999672v")
+    end
+  end
+
+  context "when the user has no permissions" do
+    before do
+      allow(ability).to receive(:can?).with(:download, member.id).and_return(false)
+      allow(ability).to receive(:can?).with(:edit, member.id).and_return(false)
+      allow(ability).to receive(:can?).with(:destroy, member.id).and_return(false)
+      render("hyrax/base/actions", member: member)
+    end
+    it "displays no links nor buttons" do
+      expect(subject).not_to have_selector('a')
+      expect(subject).not_to have_selector('button')
+    end
+  end
+end


### PR DESCRIPTION
…user can do is download. Restyle download/export buttons for clearer call to action. Closes RDR-398-download-buttons.