### PR TITLE
Enable RIIIF image server and UniversalViewer for image assets. Close…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,3 +66,5 @@ end
 group :production do
   gem 'therubyracer', platforms: :ruby
 end
+
+gem 'riiif', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -411,6 +411,8 @@ GEM
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
+    iiif-image-api (0.1.0)
+      activesupport (<= 6)
     iiif_manifest (0.5.0)
       activesupport (>= 4)
     jaro_winkler (1.5.4)
@@ -708,6 +710,10 @@ GEM
       sass-rails
       twitter-bootstrap-rails
     retriable (3.1.2)
+    riiif (2.2.0)
+      deprecation (>= 1.0.0)
+      iiif-image-api (~> 0.1.0)
+      railties (>= 4.2, < 7)
     rsolr (2.2.1)
       builder (>= 2.1.2)
       faraday (>= 0.9.0)
@@ -915,6 +921,7 @@ DEPENDENCIES
   resque
   resque-pool (~> 0.7.0)
   resque-web
+  riiif (~> 2.0)
   rsolr (>= 1.0)
   rspec-its
   rspec-rails

--- a/app/assets/stylesheets/rdr-show.scss
+++ b/app/assets/stylesheets/rdr-show.scss
@@ -11,6 +11,15 @@
   font-size:19px;
 }
 
+.viewer-wrapper {
+  margin-bottom: 1.5em;
+}
+
+.viewer {
+  padding: 0;
+  margin: 0;
+}
+
 .expandable-extended-text {
   display: none;
 }

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -142,14 +142,21 @@ Hyrax.config do |config|
   #   * iiif_image_size_default
   #
   # Default is false
-  # config.iiif_image_server = false
+  config.iiif_image_server = true
 
   # Returns a URL that resolves to an image provided by a IIIF image server
+  config.iiif_image_url_builder = lambda do |file_id, base_url, size|
+    Riiif::Engine.routes.url_helpers.image_url(file_id, host: base_url, size: size)
+  end
   # config.iiif_image_url_builder = lambda do |file_id, base_url, size|
   #   "#{base_url}/downloads/#{file_id.split('/').first}"
   # end
 
   # Returns a URL that resolves to an info.json file provided by a IIIF image server
+  config.iiif_info_url_builder = lambda do |file_id, base_url|
+    uri = Riiif::Engine.routes.url_helpers.info_url(file_id, host: base_url)
+    uri.sub(%r{/info\.json\Z}, '')
+  end
   # config.iiif_info_url_builder = lambda do |_, _|
   #   ""
   # end

--- a/config/initializers/riiif.rb
+++ b/config/initializers/riiif.rb
@@ -1,0 +1,26 @@
+Riiif::Image.file_resolver = Riiif::HTTPFileResolver.new
+Riiif::Image.info_service = lambda do |id, _file|
+  # id will look like a path to a pcdm:file
+  # (e.g. rv042t299%2Ffiles%2F6d71677a-4f80-42f1-ae58-ed1063fd79c7)
+  # but we just want the id for the FileSet it's attached to.
+
+  # Capture everything before the first slash
+  fs_id = id.sub(/\A([^\/]*)\/.*/, '\1')
+  resp = ActiveFedora::SolrService.get("id:#{fs_id}")
+  doc = resp['response']['docs'].first
+  raise "Unable to find solr document with id:#{fs_id}" unless doc
+  { height: doc['height_is'], width: doc['width_is'] }
+end
+
+Riiif::Image.file_resolver.id_to_uri = lambda do |id|
+  ActiveFedora::Base.id_to_uri(CGI.unescape(id)).tap do |url|
+    Rails.logger.info "Riiif resolved #{id} to #{url}"
+  end
+end
+
+Riiif::Image.authorization_service = Hyrax::IIIFAuthorizationService
+
+Riiif.not_found_image = Rails.root.join('app', 'assets', 'images', 'us_404.svg')
+Riiif.unauthorized_image = Rails.root.join('app', 'assets', 'images', 'us_404.svg')
+
+Riiif::Engine.config.cache_duration_in_days = 365

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,10 @@
 require 'resque_web'
 
 Rails.application.routes.draw do
-
   concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new
-  mount Blacklight::Engine => '/'
-
   concern :searchable, Blacklight::Routes::Searchable.new
+  mount Riiif::Engine => 'images', as: :riiif if Hyrax.config.iiif_image_server?
+  mount Blacklight::Engine => '/'
 
   # Resque web
   authenticate(:user, lambda {|u| u.admin?}) do


### PR DESCRIPTION
…s RDR-414.

These code revisions are the result of following the [steps documented here](https://github.com/samvera/hyrax/wiki/Hyrax-Management-Guide#image-server); most were written by generator.

I.e., this involved only:`$ rails g hyrax:riiif` and change `config.iiif_image_server` to `true`.

Note that image filesets need file characterization for this feature to work. E.g.,:
`> fs = FileSet.find("t148fh12j")`
`> CharacterizeJob.perform_now(fs, fs.files.first.id)`

I had to do the above directly in the console in my local environment. I am unsure how/when RDR does characterization in our dev/production environments.

This renders UniversalViewer on a dataset/work show page for a dataset with at least one image file. Hyrax currently includes no ability to render UV on a fileset show page, nor does it generate IIIF presentation API manifests for filesets.

![Screen Shot 2019-11-26 at 1 06 08 PM](https://user-images.githubusercontent.com/3933756/69660159-b1383b00-104d-11ea-8b1d-e3a52f920266.png)

