### PR TITLE
Support formatting in Description field; refactor existing helper int…

### DIFF
--- a/app/assets/javascripts/rdr-show.js
+++ b/app/assets/javascripts/rdr-show.js
@@ -1,7 +1,9 @@
 $(document).ready(function() {
 
-  /* Toggle expand/collapse long text, e.g., description field on show page */
-  /* Used in concert with expandable_iconify_auto_link helper method */
+  /* Toggle expand/collapse long text, e.g., description field on show page  */
+  /* Used in concert with formatted_attribute_renderer.rb which creates the */
+  /* accompanying markup. */
+
   $('a.toggle-extended-text').click(function(e){
     e.preventDefault();
     $(this).toggleClass('expanded');

--- a/app/assets/stylesheets/rdr-show.scss
+++ b/app/assets/stylesheets/rdr-show.scss
@@ -31,6 +31,9 @@ a.toggle-extended-text {
   &:focus {
    color: #2e74b2;
   }
+  &.expanded {
+    display: block;
+  }
 }
 
 .work-show-columns {

--- a/app/assets/stylesheets/rdr.scss
+++ b/app/assets/stylesheets/rdr.scss
@@ -62,6 +62,9 @@ body {
   height: auto;
 }
 
+ul.tabular {
+  padding-left: 0;
+}
 
 /* ===== */
 /* Items */

--- a/app/helpers/rdr_helper.rb
+++ b/app/helpers/rdr_helper.rb
@@ -20,25 +20,6 @@ module RdrHelper
     end
   end
 
-  # For long text (e.g., work description field): after a number of words, wrap the content
-  # in a span allowing that section to be expanded/collapsed via a "more" link, while
-  # preserving the existing icon + link rendering for URLs.
-
-  def expandable_iconify_auto_link(value)
-    words = value.split
-    word_count = words.length
-    word_limit = Rdr.expandable_text_word_cutoff
-    fullmarkup = iconify_auto_link(words[0..word_limit].join(" "))
-    if(word_count > word_limit)
-      fullmarkup << " "
-      fullmarkup << content_tag(:span, iconify_auto_link(words[(word_limit+1)..word_count].join(" ")),
-                class: "expandable-extended-text")
-      fullmarkup << " "
-      fullmarkup << link_to("... [Read More]","#", class: "toggle-extended-text")
-    end
-    fullmarkup
-  end
-
   # For nested works, characterize each node in the vertical/hierarchical breadcrumb trail to drive
   # collapse/expand behavior and presentation (e.g,. always show top-level work and direct parent work).
   def vertical_breadcrumb_node_position(pos,total_nodes)

--- a/app/renderers/formatted_attribute_renderer.rb
+++ b/app/renderers/formatted_attribute_renderer.rb
@@ -1,0 +1,42 @@
+# Patterned after 'Hyrax::Renderers::DateAttributeRenderer'
+
+# This renderer applies several formatting rules to a metadata value
+# including auto-linking URLs, converting linebreaks to <br>
+# tags, and truncating long text into an expand/collapse section
+
+class FormattedAttributeRenderer < Hyrax::Renderers::AttributeRenderer
+  private
+
+  def li_value(value)
+    value_with_br_links = auto_link(convert_linebreaks(value))
+    truncate_and_expand(value_with_br_links)
+  end
+
+  # NOTE: this gsub is used instead of Rails simple_format, which would sometimes
+  # create <p></p> tags that don't play nicely with the truncate + collapse/expand
+
+  def convert_linebreaks(value)
+    value.gsub(/(?:\n\r?|\r\n?)/, '<br/>').html_safe
+  end
+
+  def truncate_and_expand(value)
+    words = value.split
+    word_count = words.length
+    word_limit = Rdr.expandable_text_word_cutoff
+
+    formatted_text = words[0..word_limit].join(" ")
+    collapsed_text = words[(word_limit+1)..word_count]&.join(" ")
+
+    if collapsed_text.present?
+      formatted_text << [
+        " ",
+        content_tag(:span, collapsed_text.html_safe, class: "expandable-extended-text"),
+        " ",
+        link_to("... [Read More]", "#", class: "toggle-extended-text")
+      ].join
+    end
+
+    sanitized_text = sanitize(formatted_text, tags: %w(a br span strong em sup sub))
+    sanitized_text.html_safe
+  end
+end

--- a/app/views/hyrax/base/_work_description.html.erb
+++ b/app/views/hyrax/base/_work_description.html.erb
@@ -1,5 +1,5 @@
 <% presenter.description.each do |description| %>
     <p class="work_description">
-      <%= expandable_iconify_auto_link(description) %>
+      <%= presenter.attribute_to_html(:description, label: '', render_as: :formatted) %>
     </p>
 <% end %>

--- a/app/views/hyrax/datasets/_attribute_rows.html.erb
+++ b/app/views/hyrax/datasets/_attribute_rows.html.erb
@@ -69,17 +69,13 @@
 </div>
 
 
-<%# Render the main metadata elements from the top of the page again in the metadata section %>
-<%# but hide them with CSS. This ensures schema.org properties are mapped for these fields. %>
+<%# Render the title metadata element from the top of the page again in the metadata section %>
+<%# but hide it with CSS. This ensures schema.org properties are mapped for this field. %>
 <%# See Hyrax::Renderers::AttributeRenderer & Hyrax::PresentsAttributes#attribute_to_html %>
 
 <div class="hide">
   <%= presenter.attribute_to_html(:title, label: I18n.t("rdr.show.fields.title"), html_dl: true) %>
 </div>
-<div class="hide">
-  <%= presenter.attribute_to_html(:description, label: I18n.t("rdr.show.fields.description"), html_dl: true) %>
-</div>
-
 
 <%# Render the license URI with valid schema.org markup. %>
 <div class="hide">

--- a/spec/helpers/rdr_helper_spec.rb
+++ b/spec/helpers/rdr_helper_spec.rb
@@ -51,30 +51,6 @@ RSpec.describe RdrHelper, type: :helper do
     end
   end
 
-  describe '#expandable_iconify_auto_link' do
-    before do
-      Rdr.expandable_text_word_cutoff = 10
-      allow(helper).to receive(:iconify_auto_link).and_return('Foo &lt; <a href="http://www.example.com"><span class="glyphicon glyphicon-new-window"></span> http://www.example.com</a>. &amp; More text')
-    end
-    context "value has more words than the cutoff" do
-      let(:value) { 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore.' }
-      it "should have a Read More link" do
-        expect(helper.expandable_iconify_auto_link(value)).to include('[Read More]')
-      end
-      it "should call Hyrax's iconify_auto_link method for each part of the split string" do
-        expect(helper).to receive(:iconify_auto_link).with('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod')
-        expect(helper).to receive(:iconify_auto_link).with('tempor incididunt ut labore.')
-        helper.expandable_iconify_auto_link(value)
-      end
-    end
-    context "value has fewer words than the cutoff" do
-      let(:value) { 'Aenean eu convallis mi.' }
-      it "should not have a Read More link" do
-        expect(helper.expandable_iconify_auto_link(value)).not_to include('[Read More]')
-      end
-    end
-  end
-
   describe '#vertical_breadcrumb_node_position' do
     context 'current work is not deeply nested (three or fewer total ancestor nodes)' do
       let(:pos) { 2 }

--- a/spec/renderers/edtf_humanized_attribute_renderer_spec.rb
+++ b/spec/renderers/edtf_humanized_attribute_renderer_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'equivalent-xml'
 
 RSpec.describe EdtfHumanizedAttributeRenderer do
   subject { Nokogiri::HTML(renderer.render) }

--- a/spec/renderers/formatted_attribute_renderer_spec.rb
+++ b/spec/renderers/formatted_attribute_renderer_spec.rb
@@ -1,0 +1,145 @@
+require 'rails_helper'
+require 'equivalent-xml'
+
+RSpec.describe FormattedAttributeRenderer do
+  subject { Nokogiri::HTML(renderer.render_dl_row) }
+  let(:field) { :description }
+
+  before do
+    Rdr.expandable_text_word_cutoff = 10
+  end
+
+  describe "#render_dl_row" do
+    context "value has more words than the cutoff" do
+      let(:renderer) do
+        described_class.new(field,
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore.")
+      end
+      let(:expected) { Nokogiri::HTML(dl_content) }
+      let(:dl_content) do
+        %(
+        <dt>Description</dt>
+        <dd>
+          <ul class="tabular">
+            <li class="attribute attribute-description">
+              <span itemprop="description">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+                  <span class="expandable-extended-text">tempor incididunt ut labore.</span>
+                  <a class="toggle-extended-text" href="#">... [Read More]</a>
+              </span>
+            </li>
+          </ul>
+        </dd>
+        )
+      end
+      it "should have a Read More link & expandable text" do
+        expect(subject).to be_equivalent_to(expected)
+      end
+    end
+
+    context "value has fewer words than the cutoff" do
+      let(:renderer) do
+        described_class.new(field,
+        "Aenean eu convallis mi.")
+      end
+      let(:expected) { Nokogiri::HTML(dl_content) }
+      let(:dl_content) do
+        %(
+        <dt>Description</dt>
+        <dd>
+          <ul class="tabular">
+            <li class="attribute attribute-description">
+              <span itemprop="description">Aenean eu convallis mi.</span>
+            </li>
+          </ul>
+        </dd>
+        )
+      end
+      it "should not have a Read More link nor expandable text" do
+        expect(subject).to be_equivalent_to(expected)
+      end
+    end
+
+    context "value has linebreaks" do
+      let(:renderer) do
+        described_class.new(field,
+        "Thing one\nThing two\r\nThing three")
+      end
+      let(:expected) { Nokogiri::HTML(dl_content) }
+      let(:dl_content) do
+        %(
+        <dt>Description</dt>
+        <dd>
+          <ul class="tabular">
+            <li class="attribute attribute-description">
+              <span itemprop="description">
+                Thing one<br/>
+                Thing two<br/>
+                Thing three
+              </span>
+            </li>
+          </ul>
+        </dd>
+        )
+      end
+      it "should turn linebreaks to <br/> tags" do
+        expect(subject).to be_equivalent_to(expected)
+      end
+    end
+
+    context "value has URLs" do
+      let(:renderer) do
+        described_class.new(field,
+        "Go to https://library.duke.edu to learn more.")
+      end
+      let(:expected) { Nokogiri::HTML(dl_content) }
+      let(:dl_content) do
+        %(
+        <dt>Description</dt>
+        <dd>
+          <ul class="tabular">
+            <li class="attribute attribute-description">
+              <span itemprop="description">
+                Go to <a href="https://library.duke.edu">https://library.duke.edu</a> to learn more.
+              </span>
+            </li>
+          </ul>
+        </dd>
+        )
+      end
+      it "should turn linebreaks to <br/> tags" do
+        expect(subject).to be_equivalent_to(expected)
+      end
+    end
+
+    context "value has markup" do
+      before do
+        Rdr.expandable_text_word_cutoff = 100
+      end
+      let(:renderer) do
+        described_class.new(field,
+        "<h2>Alert</h2> Insert a script tag here <script>hello();</script>. <a href='#' onclick='console.log(1)'>Link with onclick behavior</a>")
+      end
+      let(:expected) { Nokogiri::HTML(dl_content) }
+      let(:dl_content) do
+        %(
+        <dt>Description</dt>
+        <dd>
+          <ul class="tabular">
+            <li class="attribute attribute-description">
+              <span itemprop="description">
+                Alert Insert a script tag here hello();.
+                <a href="#">Link with onclick behavior</a>
+              </span>
+            </li>
+          </ul>
+        </dd>
+        )
+      end
+      it "should sanitize tags" do
+        expect(subject).to be_equivalent_to(expected)
+      end
+    end
+
+  end
+end

--- a/spec/views/hyrax/datasets/_attribute_rows.html.erb_spec.rb
+++ b/spec/views/hyrax/datasets/_attribute_rows.html.erb_spec.rb
@@ -87,9 +87,6 @@ RSpec.describe 'hyrax/datasets/_attribute_rows.html.erb', type: :view do
     it "title -> name" do
       expect(page).to have_css '.attribute-title [itemprop="name"]', text: 'Example Work With Lots of Metadata Values'
     end
-    it "description -> description" do
-      expect(page).to have_css '.attribute-description [itemprop="description"]', text: /^Bicycle rights/
-    end
     it "license -> license" do
       expect(page).to have_css '.attribute-license [itemprop="license"]', text: 'http://creativecommons.org/publicdomain/mark/1.0/'
     end


### PR DESCRIPTION
…o an attribute renderer. Closes RDR-411.

This PR supports converting line-breaks to `<br/>` tags in the Description field (and preserves existing auto-link and truncate/expand functionality). Notable revisions:

- Creates a reusable "formatted" attribute renderer.
- Sets Description values to render as formatted.
- Refactors the `expandable_iconify_auto_link` helper functionality so it is part of the renderer

Note that Rails simple_format helper (which creates `<p>` tags) was not a viable solution because it would potentially split text for truncation between the opening and closing `<p></p>` tags. 

Collapsed:
<img width="910" alt="Screen Shot 2019-12-06 at 4 41 49 PM" src="https://user-images.githubusercontent.com/3933756/70358456-67b6cf80-1847-11ea-8aa2-29aacc8cc6c8.png">

Expanded:
<img width="924" alt="Screen Shot 2019-12-06 at 4 42 01 PM" src="https://user-images.githubusercontent.com/3933756/70358468-6c7b8380-1847-11ea-99d4-c2b6ac0a0b80.png">
