### PR TITLE
Add parent collection link to the vertical breadcrumb in the dataset …

### DIFF
--- a/app/presenters/hyrax/dataset_presenter.rb
+++ b/app/presenters/hyrax/dataset_presenter.rb
@@ -58,6 +58,16 @@ module Hyrax
                                  presenter_args: presenter_factory_arguments)
     end
 
+    # Uses '#member_of_collection_presenters' in Hyrax::WorkShowPresenter
+    # but only includes collections that are of the custom RDR type "Collection"
+    # This ensures other kinds of collections (admin sets, user collections, etc.)
+    # do not appear in the vertical breadcrumb.
+    #
+    # @return [Array<CollectionPresenter>] presenters
+    def member_of_rdr_collection_presenters
+      member_of_collection_presenters.select {|p| p.collection_type.machine_id == 'collection' }
+    end
+
     def ancestor_trail
       docs = ancestor_trail_ids(solr_document).map { |id| ::SolrDocument.find(id) }
       docs.reverse
@@ -73,6 +83,5 @@ module Hyrax
       ancestors.concat document.in_works_ids
       ancestor_trail_ids(::SolrDocument.find(document.in_works_ids.first), ancestors)
     end
-
   end
 end

--- a/app/views/hyrax/datasets/_vertical_breadcrumb.html.erb
+++ b/app/views/hyrax/datasets/_vertical_breadcrumb.html.erb
@@ -12,6 +12,19 @@
     </div>
   </div>
 
+  <% if presenter.member_of_rdr_collection_presenters.present? %>
+    <div class="vertical-breadcrumb-node">
+    <% presenter.member_of_rdr_collection_presenters.each do |p| %>
+      <div class='attribute attribute-title'>
+        <%= link_to p.to_s, collection_path(p.id), class: 'collection-link' %>
+      </div>
+    <% end %>
+        <div class="vertical-breadcrumb-separator">
+          <span class="fa fa-long-arrow-down"></span>
+        </div>
+    </div>
+  <% end %>
+
   <% presenter.ancestor_trail.each_with_index do |doc,i| %>
     <%= render 'vertical_breadcrumb_node', document: doc, position: vertical_breadcrumb_node_position(i+1, presenter.ancestor_trail.count) %>
   <% end %>


### PR DESCRIPTION
…showpage sidebar,  but only if it uses RDR custom collection type Collection (e.g., no Admin Set or User Collection). Closes RDR-485.