### PR TITLE
Include collections in results shown via Browse links from homepage. …

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -51,7 +51,7 @@ class CatalogController < ApplicationController
     config.add_facet_field Rdr::Index::Fields.affiliation_facet.to_s, label: I18n.t("blacklight.search.fields.facet.affiliation_sim"), limit: 5
     config.add_facet_field Rdr::Index::Fields.resource_type_facet.to_s, label: I18n.t("blacklight.search.fields.facet.resource_type_sim"), limit: 5
     config.add_facet_field Rdr::Index::Fields.pub_year.to_s, label: I18n.t("blacklight.search.fields.facet.pub_year_iim"), range: true
-    config.add_facet_field solr_name('member_of_collection_ids', :symbol), limit: 5, label: 'Collections', helper_method: :collection_title_by_id
+    config.add_facet_field solr_name('member_of_collection_ids', :symbol), show: false, limit: 5, label: 'Collections', helper_method: :collection_title_by_id
 
 
     # The generic_type isn't displayed on the facet list

--- a/app/views/hyrax/homepage/_home_content.html.erb
+++ b/app/views/hyrax/homepage/_home_content.html.erb
@@ -8,7 +8,7 @@
           main_app.new_submission_path,
           class: "btn btn-primary btn-lg btn-emphasize" %>
       <%= link_to t('hyrax.homepage.marquee.browse_button'),
-          main_app.search_catalog_path(f: { has_model_ssim: ["Dataset"], Rdr::Index::Fields.top_level => ["True"] }, latest_version: true),
+          main_app.search_catalog_path(latest_version: true, top_level: true),
           class: 'btn btn-default btn-default-darker btn-lg' %>
     </div>
   </div>

--- a/app/views/hyrax/homepage/_recently_uploaded.html.erb
+++ b/app/views/hyrax/homepage/_recently_uploaded.html.erb
@@ -7,7 +7,7 @@
   </div>
 
   <%= link_to "Browse more",
-      main_app.search_catalog_path(f: { has_model_ssim: ["Dataset"], Rdr::Index::Fields.top_level => ["True"] }, latest_version: true),
+      main_app.search_catalog_path(latest_version: true, top_level: true),
       class: 'btn btn-default btn-sm' %>
 
 <% end %>


### PR DESCRIPTION
…Suppress Collection facet. Closes RDR-497.

This solution builds on #160 (RDR-279), which establishes that search results should only include top-level works, and #323 (RDR-431) which includes collections when top_level=true is used as a parameter.

It replaces the previous functionality for the two dataset browse links from the RDR homepage, which used to lead to a search result matching Item = Dataset & Top Level: True (with removable facet selections). Now those links just go to the same place a blank search would, i.e., showing top-level Datasets and Collections together.
